### PR TITLE
Add question to verify branch when not on master.

### DIFF
--- a/bin/cut-release.js
+++ b/bin/cut-release.js
@@ -75,6 +75,7 @@ var argv = yargs.usage("Usage: cut-release [increment] [options]\n\nSupported in
 
 var version = argv._[0],
     confirm = argv.yes,
+    confirmBranch = argv.confirmBranch,
     tag = argv.tag,
     preid = argv.preid,
     dryRun = argv.d
@@ -309,11 +310,11 @@ var prompts = [
       return msg
     },
     when: function (answers) {
-      if (answers.branch === 'master') {
+      if (confirmBranch || answers.branch === 'master') {
         answers.confirmBranch = true
       }
 
-      return answers.branch !== 'master'
+      return !confirmBranch && answers.branch !== 'master'
     }
   },
   {

--- a/bin/cut-release.js
+++ b/bin/cut-release.js
@@ -299,6 +299,25 @@ var prompts = [
   },
   {
     type: 'confirm',
+    name: 'confirmBranch',
+    message: function (answers) {
+      var msg = 'Not on \'master\' branch; actually on branch \'' + answers.branch + '\'. Continue'
+      if (dryRun) {
+        msg += ' with dry run'
+      }
+      msg += '?'
+      return msg
+    },
+    when: function (answers) {
+      if (answers.branch === 'master') {
+        answers.confirmBranch = true
+      }
+
+      return answers.branch !== 'master'
+    }
+  },
+  {
+    type: 'confirm',
     name: 'confirm',
     message: function (answers) {
       var msg = 'Will bump from ' + pkg.version + ' to ' + maybeInc(answers.version, answers.preid) + ' and tag as ' + answers.tag + '. Continue'
@@ -312,7 +331,7 @@ var prompts = [
       if (confirm) {
         answers.confirm = confirm
       }
-      return !confirm
+      return !confirm && answers.confirmBranch
     }
   }
 ]
@@ -507,7 +526,7 @@ maybeSelfUpdate(function (err, shouldSelfUpdate) {
 
     log('')
     inquirer.prompt(prompts, function (answers) {
-      if (!answers.confirm) {
+      if (!answers.confirmBranch || !answers.confirm) {
         process.exit(0)
       }
       ensureCleanGit(answers, function () {


### PR DESCRIPTION
This will resolve issues from somebody accidentally cut-releasing on a branch.
The verification will still show up when using 'yes' flag, but not when on master branch.
