### PR TITLE
Only split on first occurrence of `/`

### DIFF
--- a/bin/cut-release.js
+++ b/bin/cut-release.js
@@ -445,7 +445,7 @@ function ensureCleanGit (answers, callback) {
   }
 
   function checkLocalUpToDate (callback) {
-    var parts = answers.remote.split('/')
+    var parts = answers.remote.split(/\/(.+)/)
     var remote = parts[0],
       branch = parts[1]
 
@@ -514,7 +514,7 @@ maybeSelfUpdate(function (err, shouldSelfUpdate) {
         var remote = '',
           branch = ''
         if (answers.remote) {
-          var remoteParts = answers.remote.split('/').map(function (part) {
+          var remoteParts = answers.remote.split(/\/(.+)/).map(function (part) {
             return ' ' + part;
           })
           remote = remoteParts[0]


### PR DESCRIPTION
This fixes a rare issue that occurs when trying to cut a (pre)release from a branch other than master (or any other branch that doesn’t contain a slash in the name).

In my case, the script would see `origin/fix/branch` as just `origin/fix`.