### PR TITLE
add OTP to interactive prompts; tweak option-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Options:
   -t, --tag                   NPM tag for the release (i.e. latest, next)  [string]
   -p, --preid                 NPM prerelease identifier (i.e. rc, alpha, beta)  [string]
   -d, --dry-run               Print commands to be run, but don't run them  [boolean] [default: false]
-  -m, --messasge              Version commit message - the %s variable will be replaced with the version  [string]
+  -m, --message               Version commit message - the %s variable will be replaced with the version  [string]
   --otp, --one-time-password  NPM one time password. Required if NPM 2FA is enabled  [string]
   -h, --help                  Show help  [boolean]
   -v, --version               Show version number  [boolean]

--- a/bin/cut-release.js
+++ b/bin/cut-release.js
@@ -49,12 +49,12 @@ var argv = yargs.usage("Usage: cut-release [increment] [options]\n\nSupported in
       type: 'boolean'
     },
     m: {
-      alias: 'messasge',
+      alias: 'message',
       describe: 'Version commit message - the %s variable will be replaced with the version',
       type: 'string'
     },
-    otp: {
-      alias: 'one-time-password',
+    1: {
+      alias: 'otp',
       describe: 'NPM one time password. Required if NPM 2FA is enabled',
       type: 'string'
     }
@@ -253,6 +253,18 @@ var prompts = [
       return !answers.tag
     },
     default: 'latest'
+  },
+  {
+    type: 'input',
+    name: 'otp',
+    message: 'Enter an NPM one-time password if you use 2FA',
+    when: function(answers) {
+      if (otp) {
+        answers.otp = otp
+      }
+      return !otp
+    },
+    default: null
   },
   {
     type: 'list',
@@ -535,7 +547,7 @@ maybeSelfUpdate(function (err, shouldSelfUpdate) {
           answers.setRemote && 'git branch -u ' + answers.remote,
           answers.remote && 'git push' + remote + branch,
           answers.remote && 'git push' + remote + ' v' + newVersion,
-          'npm publish' + (answers.tag ? ' --tag ' + answers.tag : '') + (otp ? ' --otp=' + otp : '')
+          'npm publish' + (answers.tag ? ' --tag ' + answers.tag : '') + (answers.otp ? ' --otp=' + answers.otp : '')
         ]
           .filter(Boolean)
 


### PR DESCRIPTION
Passing the OTP value on the command line is good, but I felt like I was racing the clock to make semver choices before it expired. This change still allows that, but adds an interactive prompt as well.

It also slightly modifies the command-line option names: `--otp` or `-1` (`-o` seemed weird since that's commonly used for "output" stuff), instead of `--otp` or `--one-time-password`. I'm open to discussion on this, for sure.